### PR TITLE
identify.primerTree_plot argument naming

### DIFF
--- a/R/primerTree.R
+++ b/R/primerTree.R
@@ -200,10 +200,10 @@ env2list = function(env){
 }
 #' identify the point closest to the mouse click
 #' only works on single ranks
-#' @param x the plot to identify
+#' @param plot the plot to identify
 #' @param ... additional arguments passed to annotate
 #' @export
-identify.primerTree_plot = function(x, ...) {
+identify.primerTree_plot = function(plot, ...) {
   point = gglocator(plot$layers[[4]])
   distances <- distance(point, plot$layers[[4]]$data[,c('x','y')])
   closest <- which(distances == min(distances))[1]


### PR DESCRIPTION
For me at least, `identify(x,...)` consistently throws "object of type 'closure' is not subsettable" even when `x` is a valid `primerTree_plot`. This patch simply renames the formal argument `x` to be `plot`, same as used inside the function.
