### PR TITLE
switch parsers to give xpathApply the object class it expects

### DIFF
--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -35,7 +35,7 @@ gi2taxid = function(gi){
   #stop if response failed
   stop_for_status(response)
 
-  parsed = content(response, type='text/xml')
+  parsed = xmlParse(content(response, type='text/xml', as="text"))
 
   xpathSApply(parsed, '//LinkSet', parse_LinkSet)
 }
@@ -81,7 +81,7 @@ fetch_taxonomy = function(taxid) {
   #stop if response failed
   stop_for_status(response)
 
-  parse_taxonomy_xml(content(response))
+  parse_taxonomy_xml(xmlParse(content(response, as="text")))
 }
 parse_taxonomy_xml = function(xml){
   rbind.fill(xpathApply(xml, '//TaxaSet/Taxon', parse_taxon))


### PR DESCRIPTION
Proposed fix, or perhaps band-aid, for #20. These changes are cribbed directly from https://github.com/DataONEorg/rdataone/issues/125 -- see there for more discussion, but the underlying issue seems to be that `httr` switched from using `XML` to `xml2` for parsing and therefore returns an xml_document instead of an XMLInternalDocument. This patch switches `httr::content` from parsed to text and wraps it in `XML::xmlParse` to get the XMLInternalDocument expected by `xpathApply`.
