### PR TITLE
Update search.R

### DIFF
--- a/R/search.R
+++ b/R/search.R
@@ -48,7 +48,8 @@ enumerate_primers = function(forward, reverse){
   forward_primers = enumerate_ambiguity(forward)
   data.frame(forward=forward_primers,
              reverse=rep(enumerate_ambiguity(reverse),
-                         each=length(forward_primers)))
+                         each=length(forward_primers)),
+             stringsAsFactors = F)
 }
 enumerate_ambiguity = function(sequence){
   search_regex = paste(names(iupac), collapse='|')


### PR DESCRIPTION
Changing the way the data frame is created in the enumerate_primers function to keep primer sequences as characters and not factors