### PR TITLE
Fix for issue #28

### DIFF
--- a/R/primerTree.R
+++ b/R/primerTree.R
@@ -151,6 +151,8 @@ search_primer_pair = function(forward, reverse, name=NULL, num_aligns=500,
       primer_search$BLAST_result =
         filter_duplicates(ldply(primer_search$response, parse_primer_hits, .parallel=.parallel))
 
+      primer_search$BLAST_result$gi <- as.character(primer_search$BLAST_result$gi)
+      
       message(nrow(primer_search$BLAST_result), ' BLAST alignments parsed in ', seconds_elapsed_text(start_time))
 
       start_time = now()

--- a/R/search.R
+++ b/R/search.R
@@ -48,7 +48,8 @@ enumerate_primers = function(forward, reverse){
   forward_primers = enumerate_ambiguity(forward)
   data.frame(forward=forward_primers,
              reverse=rep(enumerate_ambiguity(reverse),
-                         each=length(forward_primers)))
+                         each=length(forward_primers)),
+             stringsAsFactors = F)
 }
 enumerate_ambiguity = function(sequence){
   search_regex = paste(names(iupac), collapse='|')

--- a/R/search.R
+++ b/R/search.R
@@ -49,7 +49,7 @@ enumerate_primers = function(forward, reverse){
   data.frame(forward=forward_primers,
              reverse=rep(enumerate_ambiguity(reverse),
                          each=length(forward_primers)),
-             stringsAsFactors = F)
+             stringsAsFactors = FALSE)
 }
 enumerate_ambiguity = function(sequence){
   search_regex = paste(names(iupac), collapse='|')


### PR DESCRIPTION
This changes the behavior of the "enumerate_primers" function to create a dataframe of primers stored as characters and not as factors. 